### PR TITLE
コマンドのprefixを `!` に変更する

### DIFF
--- a/discordbot.py
+++ b/discordbot.py
@@ -2,7 +2,7 @@ from discord.ext import commands
 from os import getenv
 import traceback
 
-bot = commands.Bot(command_prefix='/')
+bot = commands.Bot(command_prefix='!')
 
 
 @bot.event


### PR DESCRIPTION
コマンドのprefixとして `!` を使用するように変更する